### PR TITLE
Make Bounded record type extensible

### DIFF
--- a/src/QuadTree.elm
+++ b/src/QuadTree.elm
@@ -186,8 +186,8 @@ subdivideSE box =
 ---------
 {-| Extend this record type in order to use the QuadTree.
 -}
-type alias Bounded a = {
-  boundingBox : BoundingBox
+type alias Bounded a = { 
+  a | boundingBox : BoundingBox
 }
 
 ---------


### PR DESCRIPTION
Hey, I may be misunderstanding Elm's extensible records, but was this the intended implementation of the Bounded record type?
